### PR TITLE
Update/move compounder

### DIFF
--- a/src/@demex-info/constants/links.ts
+++ b/src/@demex-info/constants/links.ts
@@ -77,6 +77,8 @@ export const Paths = {
     Main: "/nitron",
     Liquidations: "/liquidations",
   },
+
+  Promotions: "/promotions",
 };
 
 export const DemexHosts: { [key: string]: string } = {

--- a/src/@demex-info/hooks/useHeaderLinks.ts
+++ b/src/@demex-info/hooks/useHeaderLinks.ts
@@ -1,5 +1,5 @@
 import { DropdownMenuItem, NavLink, Paths, StaticLinks, getDemexLink, goToDemexLink } from "@demex-info/constants";
-import { GLPCompounder, MenuPools, MenuStake, ReferralIcon, TrophyIcon } from "@demex-info/layout/MainLayout/components/Header/assets";
+import { GLPCompounder, MenuPools, MenuStake } from "@demex-info/layout/MainLayout/components/Header/assets";
 import actions from "@demex-info/store/actions";
 import { RootState } from "@demex-info/store/types";
 import { useMemo } from "react";
@@ -18,9 +18,6 @@ export default (): LinksReturn => {
 
   const handleEarnOpen = () => dispatch(actions.App.setEarnDrawerOpen(true));
   const handleEarnClose = () => dispatch(actions.App.setEarnDrawerOpen(false));
-
-  const handlePromotionsOpen = () => dispatch(actions.App.setPromotionsDrawerOpen(true));
-  const handlePromotionsClose = () => dispatch(actions.App.setPromotionsDrawerOpen(false));
 
   return useMemo(() => {
     const earnLinks: DropdownMenuItem[] = [{
@@ -42,19 +39,6 @@ export default (): LinksReturn => {
       startIcon: GLPCompounder,
       startIconType: "fill",
     }];
-    const promotionLinks: DropdownMenuItem[] = [{
-      key: "demex-mega-marathon",
-      label: "Demex Mega Marathon",
-      onClick: () => goToDemexLink(getDemexLink(Paths.Competition.Leaderboard, net)),
-      startIcon: TrophyIcon,
-      startIconType: "fill",
-    }, {
-      key: "referrals",
-      label: "Referrals",
-      onClick: () => goToDemexLink(getDemexLink(Paths.Account.Referrals, net)),
-      startIcon: ReferralIcon,
-      startIconType: "fill",
-    }];
     const navLinksArr: NavLink[] = [
       {
         label: "Trade",
@@ -74,11 +58,7 @@ export default (): LinksReturn => {
       },
       {
         label: "Promotions",
-        href: undefined,
-        dropdownItems: promotionLinks,
-        open: promotionsOpen,
-        onHandleOpen: handlePromotionsOpen,
-        onHandleClose: handlePromotionsClose,
+        href: getDemexLink(Paths.Promotions, net),
       },
       {
         showIcon: true,

--- a/src/@demex-info/hooks/useHeaderLinks.ts
+++ b/src/@demex-info/hooks/useHeaderLinks.ts
@@ -30,17 +30,17 @@ export default (): LinksReturn => {
       startIcon: MenuPools,
       startIconType: "fill",
     }, {
-      key: "glp-compounder",
-      label: "GLP Compounder",
-      onClick: () => goToDemexLink(getDemexLink(Paths.Strategy.GLPWrapper, net)),
-      startIcon: GLPCompounder,
-      startIconType: "fill",
-    }, {
       key: "staking",
       onClick: () => goToDemexLink(getDemexLink(Paths.Stake.List, net)),
       label: "Stake SWTH",
       startIcon: MenuStake,
       startIconType: "stroke",
+    }, {
+      key: "glp-compounder",
+      label: "GLP Compounder",
+      onClick: () => goToDemexLink(getDemexLink(Paths.Strategy.GLPWrapper, net)),
+      startIcon: GLPCompounder,
+      startIconType: "fill",
     }];
     const promotionLinks: DropdownMenuItem[] = [{
       key: "demex-mega-marathon",

--- a/src/@demex-info/layout/MainLayout/components/Footer/components/NavFooter.tsx
+++ b/src/@demex-info/layout/MainLayout/components/Footer/components/NavFooter.tsx
@@ -24,17 +24,17 @@ const NavFooter: React.FC = () => {
       label: "Trade",
       href: getDemexLink(Paths.Trade, net),
     }, {
-      label: "Pools",
-      href: getDemexLink(Paths.Pools.List, net),
-    }, {
       label: "Nitron",
       href: getDemexLink(Paths.Nitron.Main, net),
     }, {
-      label: "GLP Compounder",
-      href: getDemexLink(Paths.Strategy.GLPWrapper, net),
+      label: "Pools",
+      href: getDemexLink(Paths.Pools.List, net),
     }, {
       label: "Stake SWTH",
       href: getDemexLink(Paths.Stake.List, net),
+    }, {
+      label: "GLP Compounder",
+      href: getDemexLink(Paths.Strategy.GLPWrapper, net),
     }],
   }, {
     title: "Resources",


### PR DESCRIPTION
- Reorganise Earn links in the following order:
  - Pools
  - Stake SWTH
  - GLP Compounder
- Make single-redirect Promotions link