### PR TITLE
Revert "Double trading volume (#147)"

### DIFF
--- a/src/@demex-info/views/HeroSection/components/MarketsGrid.tsx
+++ b/src/@demex-info/views/HeroSection/components/MarketsGrid.tsx
@@ -244,9 +244,6 @@ const MarketsGrid: React.FC = () => {
       }
     });
 
-    // new definition: $1 traded = $1 buy and $1 sell = $2 volume
-    volume24H = volume24H.times(2);
-
     return {
       volume24H,
       coinsList,


### PR DESCRIPTION
This reverts commit 12b3b3c8c68a788c9abced1042ca6e30998500a9, which double-counts the 24H trading volume.

After clarification during the Demex frontend meeting at 11a.m. on 6 Nov 2023, it is deemed that double-counting is incorrect, hence the original calculation is restored (i.e. $1 maker + $1 taker is considered $1 traded).